### PR TITLE
fixed duplicate label

### DIFF
--- a/src/app/analyze/[videoId]/page.tsx
+++ b/src/app/analyze/[videoId]/page.tsx
@@ -1365,7 +1365,10 @@ export default function YouTubeVideoAnalyzePage() {
     uiStore.setShowSegmentation(showSegmentation);
     uiStore.setIsChatbotOpen(isChatbotOpen);
     uiStore.setIsLyricsPanelOpen(isLyricsPanelOpen);
-    uiStore.initializeOriginalKey(keySignature || 'C');
+    // CRITICAL FIX: Extract just the note name from key signature (e.g., "E♭ major" -> "E♭")
+    // to prevent duplicate "major/minor" text when pitch shift is enabled
+    const noteName = keySignature ? keySignature.split(' ')[0] : 'C';
+    uiStore.initializeOriginalKey(noteName);
     uiStore.initializeFirebaseAudioAvailable(!!audioProcessingState.audioUrl);
 
     // Initialize PlaybackStore


### PR DESCRIPTION
## Description
- The bug was in src/app/analyze/[videoId]/page.tsx line 1368, where the full key signature (e.g., "G major") was being passed to initializeOriginalKey() instead of just the note name (e.g., "G").
- Solution
```
// CRITICAL FIX: Extract just the note name from key signature (e.g., "E♭ major" -> "E♭")
// to prevent duplicate "major/minor" text when pitch shift is enabled
const noteName = keySignature ? keySignature.split(' ')[0] : 'C';
uiStore.initializeOriginalKey(noteName);
```