### PR TITLE
fixed inversion note not parsed correctly

### DIFF
--- a/src/components/ChordGridContainer.tsx
+++ b/src/components/ChordGridContainer.tsx
@@ -68,7 +68,6 @@ interface ChordGridContainerProps {
   isEditMode?: boolean;
   editedChords?: Record<number, string>;
   onChordEdit?: (index: number, newChord: string) => void;
-  // NEW: Enable refactored version with context and performance optimizations
   useRefactoredVersion?: boolean;
   enableVirtualization?: boolean;
   virtualizationThreshold?: number;
@@ -89,7 +88,7 @@ export const ChordGridContainer: React.FC<ChordGridContainerProps> = React.memo(
   isEditMode = false,
   editedChords = {},
   onChordEdit,
-  useRefactoredVersion = false,
+  useRefactoredVersion = false, 
   enableVirtualization = true,
   virtualizationThreshold = 100,
 }) => {


### PR DESCRIPTION
## Description
**The bug**: The function was treating /4 as a literal string and appending it to octave "2", creating "42" instead of converting it to the actual note name. The smplr soundfont library cannot play note "42" (it expects "[note]2"), so the bass note was completely silent, making inverted chords sound identical to root position chords.

**Solution**:
- Added a new `intervalToSemitones()` function that interprets the Python backend's delta notation:
> /1 = 0 semitones (root)
/2 = 2 semitones (major second)
/3 = 4 semitones (major third)
/4 = 5 semitones (perfect fourth) ← This was the issue!
/5 = 7 semitones (perfect fifth)
/b7 = 10 semitones (minor seventh)
/7 = 11 semitones (major seventh)