### PR TITLE
minor fix to stabilize loading

### DIFF
--- a/src/components/homepage/LazyRecentVideos.tsx
+++ b/src/components/homepage/LazyRecentVideos.tsx
@@ -7,25 +7,27 @@ const RecentVideos = lazy(() => import('./RecentVideos'));
 
 // Loading skeleton component
 const RecentVideosLoading = () => (
-  <div className="space-y-4">
-    <div className="flex items-center justify-between">
-      <div className="h-6 bg-gray-200 dark:bg-gray-700 rounded w-48 animate-pulse"></div>
-      <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-24 animate-pulse"></div>
+  <div className="w-full bg-content1 dark:bg-content1 border border-divider dark:border-divider rounded-lg">
+    <div className="flex items-center justify-between px-4 py-3 border-b border-divider dark:border-divider">
+      <div className="h-5 w-48 bg-gray-200 dark:bg-gray-700 rounded animate-pulse"></div>
+      <div className="h-4 w-20 bg-gray-200 dark:bg-gray-700 rounded animate-pulse"></div>
     </div>
-    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-      {Array.from({ length: 8 }).map((_, i) => (
-        <div key={i} className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 overflow-hidden animate-pulse">
-          <div className="aspect-video bg-gray-200 dark:bg-gray-700"></div>
-          <div className="p-4 space-y-3">
-            <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-3/4"></div>
-            <div className="h-3 bg-gray-200 dark:bg-gray-700 rounded w-1/2"></div>
-            <div className="flex items-center space-x-2">
-              <div className="h-3 bg-gray-200 dark:bg-gray-700 rounded w-16"></div>
-              <div className="h-3 bg-gray-200 dark:bg-gray-700 rounded w-12"></div>
+    <div className="h-96 overflow-hidden p-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3 pr-2">
+        {[...Array(6)].map((_, i) => (
+          <div key={i} className="w-full bg-content2 dark:bg-content2 border border-divider dark:border-divider rounded-md">
+            <div className="p-3">
+              <div className="flex gap-3">
+                <div className="w-20 h-12 bg-gray-200 dark:bg-gray-700 rounded-md animate-pulse"></div>
+                <div className="flex-1 space-y-2">
+                  <div className="h-4 w-3/4 bg-gray-200 dark:bg-gray-700 rounded animate-pulse"></div>
+                  <div className="h-3 w-1/2 bg-gray-200 dark:bg-gray-700 rounded animate-pulse"></div>
+                </div>
+              </div>
             </div>
           </div>
-        </div>
-      ))}
+        ))}
+      </div>
     </div>
   </div>
 );

--- a/src/components/homepage/NewHomePageContent.tsx
+++ b/src/components/homepage/NewHomePageContent.tsx
@@ -20,7 +20,31 @@ import SupportChordMini from '@/components/homepage/SupportChordMini'
 
 // Dynamic imports for heavy components
 const RecentVideos = dynamic(() => import('@/components/homepage/LazyRecentVideos'), {
-  loading: () => <div className="animate-pulse bg-gray-200 dark:bg-slate-700 rounded-lg h-32"></div>,
+  loading: () => (
+    <div className="w-full bg-content1 dark:bg-content1 border border-divider dark:border-divider rounded-lg">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-divider dark:border-divider">
+        <div className="h-5 w-48 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
+        <div className="h-4 w-20 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
+      </div>
+      <div className="h-96 overflow-hidden p-4">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3 pr-2">
+          {[...Array(6)].map((_, i) => (
+            <div key={i} className="w-full bg-content2 dark:bg-content2 border border-divider dark:border-divider rounded-md">
+              <div className="p-3">
+                <div className="flex gap-3">
+                  <div className="w-20 h-12 bg-gray-200 dark:bg-gray-700 rounded-md animate-pulse" />
+                  <div className="flex-1 space-y-2">
+                    <div className="h-4 w-3/4 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
+                    <div className="h-3 w-1/2 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
+                  </div>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  ),
   ssr: false
 });
 
@@ -258,10 +282,9 @@ function NewHomePageContentInner() {
         {/* Content */}
         <div className="relative z-10 max-w-7xl mx-auto px-6">
           <motion.div
-            initial={{ opacity: 0, y: 30 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: true, margin: "-100px" }}
-            transition={{ duration: 0.8 }}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ duration: 0.6 }}
             className="text-center mb-12"
           >
             <h2 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-white mb-4">
@@ -273,10 +296,9 @@ function NewHomePageContentInner() {
           </motion.div>
 
           <motion.div
-            initial={{ opacity: 0, y: 30 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: true, margin: "-100px" }}
-            transition={{ duration: 0.8, delay: 0.2 }}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ duration: 0.6, delay: 0.2 }}
           >
             <RecentVideos />
           </motion.div>

--- a/src/components/homepage/RecentVideos.tsx
+++ b/src/components/homepage/RecentVideos.tsx
@@ -351,16 +351,10 @@ export default function RecentVideos() {
     return serviceMap[service] || service;
   };
 
-  // PERFORMANCE FIX #5: Show placeholder until component is visible
-  if (!isVisible) {
-    return (
-      <div ref={containerRef} className="w-full h-96 bg-content1 dark:bg-content1 border border-divider dark:border-divider rounded-lg" />
-    );
-  }
 
   if (loading) {
     return (
-      <Card ref={containerRef} className="w-full bg-content1 dark:bg-content1 border border-divider dark:border-divider">
+      <Card ref={containerRef} style={{ contentVisibility: 'auto', containIntrinsicSize: '384px' }} className="w-full bg-content1 dark:bg-content1 border border-divider dark:border-divider">
         <CardHeader className="flex justify-between items-center pb-2">
           <h3 className="text-xl font-medium">Recently Transcribed Songs</h3>
           <Chip size="md" variant="flat" color="default">Loading...</Chip>
@@ -381,11 +375,32 @@ export default function RecentVideos() {
   }
 
   if (error || videos.length === 0) {
-    return null;
+    return (
+      <Card ref={containerRef} style={{ contentVisibility: 'auto', containIntrinsicSize: '384px' }} className="w-full bg-content1 dark:bg-content1 border border-divider dark:border-divider">
+        <CardHeader className="flex justify-between items-center pb-2">
+          <h3 className="text-lg font-medium">Recently Transcribed Songs</h3>
+          <Chip size="sm" variant="flat" color={error ? "danger" : "default"}>
+            {error ? "Error" : "Empty"}
+          </Chip>
+        </CardHeader>
+        <CardBody className="p-0">
+          <div className="h-96 flex items-center justify-center p-6">
+            <div className="text-center">
+              <h4 className="text-base font-medium text-gray-800 dark:text-gray-100 mb-1">
+                {error ? 'Failed to load transcribed videos' : 'No recent transcriptions yet'}
+              </h4>
+              <p className="text-sm text-gray-600 dark:text-gray-300">
+                {error ? 'Please retry or check your connection.' : 'New analyses will appear here as they are created.'}
+              </p>
+            </div>
+          </div>
+        </CardBody>
+      </Card>
+    );
   }
 
   return (
-    <Card ref={containerRef} className="w-full bg-content1 dark:bg-content1 border border-divider dark:border-divider">
+    <Card ref={containerRef} style={{ contentVisibility: 'auto', containIntrinsicSize: '384px' }} className="w-full bg-content1 dark:bg-content1 border border-divider dark:border-divider">
       <CardHeader className="flex justify-between items-center pb-2">
         <h3 className="text-lg font-medium">Recently Transcribed Songs</h3>
         <Chip size="sm" variant="flat" color="default" className="text-foreground dark:text-white">
@@ -394,7 +409,7 @@ export default function RecentVideos() {
       </CardHeader>
 
       <CardBody className="p-0">
-        <div className={`${isExpanded ? 'h-[672px]' : 'h-96'} overflow-y-auto scrollbar-thin p-4 transition-all duration-300 ease-in-out`}>
+        <div className={`${isExpanded ? 'h-[672px]' : 'h-96'} overflow-y-auto scrollbar-thin p-4 transition-opacity duration-300 ease-in-out`}>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3 pr-2">
             {videos.map((video) => (
               <Card


### PR DESCRIPTION
### Description
The instability and CLS warnings in Chrome caused by a feedback loop between viewport-triggered animations and IntersectionObserver-based lazy rendering

#### Fixes
- Removed viewport-triggered y-translation near the observed element
  - Changed the “Recent Analyses” heading and the wrapper around from whileInView + y-translation to a simple opacity-only mount animation (animate with initial/animate).
  - Result: The section no longer moves while Chrome is measuring intersections, eliminating the observed “in/out” thrash that caused flicker and CLS.
- Ensured stable-height rendering in all states
  - Dynamic import fallback and Suspense fallback updated to reserve the final height (h-96) and match the grid skeleton layout.
  - Error/empty states now render a fixed-height Card instead of returning null.
  - Result: No large height jumps on mount, and no collapse/expand oscillations during transient states.
- Removed height transitions from the scroll container
  - Replaced transition-all with transition-opacity.
  - Result: Height changes (like Show More/Less) don’t get counted as layout shifts (CLS) by Chrome.
- Added CSS containment to isolate internal layout changes
  - Added style={{ contentVisibility: 'auto', containIntrinsicSize: '384px' }} to the outer Card in loading, error/empty, and success branches.
  - Result: Chrome treats internal updates more like a contained subtree; reduces layout shift propagation.
Together, these changes stopped the flicker, kept the section visible on first load, and dropped CLS below the 0.1 target without needing the theme-toggling workaround.