### PR TITLE
automatic blob clean up resolved

### DIFF
--- a/src/app/api/blob/delete/route.ts
+++ b/src/app/api/blob/delete/route.ts
@@ -1,4 +1,4 @@
-import { del } from '@vercel/blob';
+import { del, BlobNotFoundError } from '@vercel/blob';
 import { NextRequest, NextResponse } from 'next/server';
 import { validateBlobUrl } from '@/utils/blobValidation';
 
@@ -57,7 +57,7 @@ export async function POST(request: NextRequest) {
     console.error('❌ Blob deletion failed:', errorMessage);
 
     // BlobNotFoundError means it's already deleted — treat as success
-    if (errorMessage.includes('not found')) {
+    if (error instanceof BlobNotFoundError) {
       return NextResponse.json({ success: true, alreadyDeleted: true });
     }
 

--- a/src/app/api/detect-beats-blob/route.ts
+++ b/src/app/api/detect-beats-blob/route.ts
@@ -46,13 +46,20 @@ export async function POST(request: NextRequest) {
     const formData = await request.formData();
 
     // Validate that we have a Blob URL
-    const rawBlobUrl = formData.get('blob_url') as string;
-    if (!rawBlobUrl) {
+    const blobUrlEntry = formData.get('blob_url');
+    if (blobUrlEntry == null) {
       return NextResponse.json(
         { error: 'No Vercel Blob URL provided' },
         { status: 400 }
       );
     }
+    if (typeof blobUrlEntry !== 'string') {
+      return NextResponse.json(
+        { error: 'Invalid Vercel Blob URL: expected a string form field, but received a file upload' },
+        { status: 400 }
+      );
+    }
+    const rawBlobUrl = blobUrlEntry;
 
     // Strict URL validation — parse and enforce hostname allowlist
     let blobUrl: string;
@@ -101,13 +108,15 @@ export async function POST(request: NextRequest) {
       console.warn(`⚠️ Failed to get audio duration, using default: ${error}`);
     }
 
-    // Non-blocking cleanup: delete the blob now that we have the data in memory
-    // and metadata extraction is complete
-    del(blobUrl).then(() => {
+    // Cleanup: delete the blob now that we have the data in memory and metadata
+    // extraction is complete. Awaited to ensure it runs reliably in serverless
+    // environments, but failures are treated as non-critical.
+    try {
+      await del(blobUrl);
       console.log(`🗑️ Blob deleted after download: ${blobUrl.substring(0, 80)}...`);
-    }).catch((err) => {
+    } catch (err) {
       console.warn(`⚠️ Non-critical: failed to delete blob after download:`, err);
-    });
+    }
 
     // Calculate dynamic timeout based on audio duration
     const timeoutValue = calculateProcessingTimeout(audioDuration);

--- a/src/app/api/recognize-chords-blob/route.ts
+++ b/src/app/api/recognize-chords-blob/route.ts
@@ -22,13 +22,20 @@ export async function POST(request: NextRequest) {
     const formData = await request.formData();
 
     // Validate that we have a Blob URL
-    const rawBlobUrl = formData.get('blob_url') as string;
-    if (!rawBlobUrl) {
+    const blobUrlEntry = formData.get('blob_url');
+    if (blobUrlEntry == null) {
       return NextResponse.json(
         { error: 'No Vercel Blob URL provided' },
         { status: 400 }
       );
     }
+    if (typeof blobUrlEntry !== 'string') {
+      return NextResponse.json(
+        { error: 'Invalid Vercel Blob URL: expected a string form field, but received a file upload' },
+        { status: 400 }
+      );
+    }
+    const rawBlobUrl = blobUrlEntry;
 
     // Strict URL validation — parse and enforce hostname allowlist
     let blobUrl: string;
@@ -55,12 +62,15 @@ export async function POST(request: NextRequest) {
     const audioBuffer = await blobResponse.arrayBuffer();
     const audioBlob = new Blob([audioBuffer], { type: 'audio/wav' });
 
-    // Non-blocking cleanup: delete the blob now that we have the data in memory
-    del(blobUrl).then(() => {
+    // Cleanup: delete the blob now that we have the data in memory. Awaited to
+    // ensure it runs reliably in serverless environments, but failures are
+    // treated as non-critical.
+    try {
+      await del(blobUrl);
       console.log(`🗑️ Blob deleted after download: ${blobUrl.substring(0, 80)}...`);
-    }).catch((err) => {
+    } catch (err) {
       console.warn(`⚠️ Non-critical: failed to delete blob after download:`, err);
-    });
+    }
 
     // Extract filename from blob URL or use default
     const urlParts = blobUrl.split('/');

--- a/src/services/storage/vercelBlobUploadService.ts
+++ b/src/services/storage/vercelBlobUploadService.ts
@@ -134,13 +134,18 @@ class VercelBlobUploadService {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ url: blobUrl }),
+      keepalive: true, // Ensure the request completes even during page transitions
     })
-      .then((res) => {
+      .then(async (res) => {
         if (res.ok) {
-          console.log(`\uD83D\uDDD1\uFE0F Client cleanup: blob deleted`);
-        } else if (res.status === 404) {
-          // Blob not found — already deleted by the API route
-          console.info(`\u2139\uFE0F Client cleanup: blob not found (already deleted)`);
+          // The API returns { alreadyDeleted: true } when the blob was already
+          // removed server-side, so parse the body to distinguish.
+          const data = await res.json().catch(() => ({}));
+          if (data.alreadyDeleted) {
+            console.info(`\u2139\uFE0F Client cleanup: blob already deleted by server`);
+          } else {
+            console.log(`\uD83D\uDDD1\uFE0F Client cleanup: blob deleted`);
+          }
         } else if (res.status >= 500) {
           // Server-side issue — log as warning so misconfigurations are visible
           console.warn(

--- a/src/utils/blobValidation.ts
+++ b/src/utils/blobValidation.ts
@@ -31,8 +31,11 @@ function hostMatchesAllowlist(hostname: string): boolean {
  * @throws  Error with a safe, non-leaking message on failure.
  */
 export function validateBlobUrl(url: unknown): string {
-  if (typeof url !== 'string' || url.length === 0) {
+  if (url == null || (typeof url === 'string' && url.length === 0)) {
     throw new Error('No blob URL provided');
+  }
+  if (typeof url !== 'string') {
+    throw new Error('Invalid blob URL');
   }
 
   let parsed: URL;


### PR DESCRIPTION
## Changes Made

### 1. New file: `route.ts`

- API route that uses `del()` from `@vercel/blob` to delete blobs by URL  
- Validates URL format and handles `"already deleted"` gracefully  

---

### 2. Modified: `route.ts`

- Imports `del` from `@vercel/blob`  
- **Primary cleanup**: Fires a non-blocking `del(blobUrl)` immediately after downloading the blob into memory (before forwarding to Python).  
  - Errors are caught and logged without affecting the response.

---

### 3. Modified: `route.ts`

- Same pattern as detect-beats-blob: non-blocking `del()` right after download  

---

### 4. Modified: `vercelBlobUploadService.ts`

- Added `deleteBlobUrl()` private method — a fire-and-forget client-side safety net that calls `/api/blob/delete`  
- Called after successful processing in both:
  - `detectBeatsBlobUpload()`
  - `recognizeChordsBlobUpload()`

---

## Design Decisions

| Concern | Approach |
|----------|----------|
| When to delete | Immediately after the API route downloads blob into memory (Option A) |
| Non-blocking | `del()` is called without `await` — cleanup never delays the response |
| Failed processing | Blob is deleted after download, before Python processing — even if Python fails, the blob is already cleaned up (data is safely in memory) |
| Network errors during deletion | Caught and logged as warnings, never thrown |
| Concurrent/duplicate deletes | The client-side safety net may fire after the server already deleted — `"not found"` errors are treated as success |
| Defense in depth | Two layers: server-side `del()` (primary) + client-side `/api/blob/delete` call (safety net) |