### PR TITLE
Add alternative download script for model checkpoints (Git LFS workaround)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -285,6 +285,7 @@ scripts/*
 !scripts/pre-deployment-checklist.sh
 !scripts/publish-repowiki-to-github-wiki.sh
 !scripts/post-deployment-verification.sh
+!scripts/download_model_checkpoints.sh
 
 __tests__/
 __tests__/*

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Synchronized lyrics transcription with AI chatbot for contextual music analysis 
 - **Node.js 20.9+** and **npm 10+**
 - **Python 3.10.x** (3.10.16 recommended for the backend)
 - **Docker** (recommended for the standalone Sheet Sage melody service)
-- **Git LFS** (for SongFormer checkpoints)
+- **Git LFS** (for SongFormer checkpoints — if LFS bandwidth is exceeded, see [Alternative: script download](#alternative-download-model-checkpoints) below)
 - **Firebase account** (free tier)
 - **Gemini API** (free tier)
 
@@ -100,12 +100,29 @@ Synchronized lyrics transcription with AI chatbot for contextual music analysis 
 > [!NOTE]
 > `git lfs pull` downloads the large SongFormer model files referenced by this repo, including the checkpoint binaries stored as Git LFS objects.
 
+> [!TIP]
+> **Git LFS bandwidth exceeded?** See [Alternative download](#alternative-download-model-checkpoints) below.
+
 #### Verify that submodules are populated
 ```bash
 ls -la python_backend/models/Beat-Transformer/
 ls -la python_backend/models/Chord-CNN-LSTM/
 ls -la python_backend/models/ChordMini/
 ```
+
+#### Alternative: Download model checkpoints without Git LFS
+
+If you hit the Git LFS bandwidth limit (free accounts get 1 GB/month), or prefer not to use LFS:
+
+```bash
+git clone --recursive https://github.com/ptnghia-j/ChordMiniApp.git
+cd ChordMiniApp
+GIT_LFS_SKIP_SMUDGE=1 git lfs pull  # downloads LFS pointer files, not binaries
+chmod +x scripts/download_model_checkpoints.sh
+./scripts/download_model_checkpoints.sh
+```
+
+This downloads the same checkpoint files from the [GitHub Releases](https://github.com/ptnghia-j/ChordMiniApp/releases/tag/model-checkpoints-v1) instead of Git LFS. Place them at the expected paths. See `scripts/download_model_checkpoints.sh` for the full file list.
 
 > [!NOTE]
 > If chord recognition encounters an issue with FluidSynth, install it for MIDI synthesis.

--- a/scripts/download_model_checkpoints.sh
+++ b/scripts/download_model_checkpoints.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# download_model_checkpoints.sh
+#
+# Alternative download for ChordMiniApp model checkpoints when Git LFS
+# bandwidth is exhausted or unavailable.
+#
+# Usage:
+#   chmod +x scripts/download_model_checkpoints.sh
+#   ./scripts/download_model_checkpoints.sh
+#
+# Each checkpoint is placed where git lfs would have put it.
+# After downloading, skip the `git lfs pull` step — these files
+# already exist at the correct paths.
+
+set -euo pipefail
+
+BASE_URL="https://github.com/ptnghia-j/ChordMiniApp/releases/download/model-checkpoints-v1"
+CHECKPOINT_DIR="SongFormer/src/SongFormer/ckpts"
+
+# Map of relative path → file in the GH Release
+declare -A FILES
+FILES["${CHECKPOINT_DIR}/SongFormer.safetensors"]="${BASE_URL}/SongFormer.safetensors"
+FILES["${CHECKPOINT_DIR}/MuQ/model.safetensors"]="${BASE_URL}/MuQ-model.safetensors"
+FILES["${CHECKPOINT_DIR}/MusicFM/pretrained_msd.pt"]="${BASE_URL}/pretrained_msd.pt"
+
+# Also download the ChordMini/Chord-CNN-LSTM model checkpoints if absent
+CHORD_BASE_URL="https://github.com/ptnghia-j/ChordMiniApp/releases/download/model-checkpoints-v1"
+FILES["python_backend/models/ChordMini/checkpoints/btc_model_best.pth"]="${CHORD_BASE_URL}/btc_model_best.pth"
+FILES["python_backend/models/ChordMini/checkpoints/2e1d_model_best.pth"]="${CHORD_BASE_URL}/2e1d_model_best.pth"
+FILES["python_backend/models/ChordMini/checkpoints/btc_model_large_voca.pt"]="${CHORD_BASE_URL}/btc_model_large_voca.pt"
+
+echo "Downloading model checkpoints..."
+echo ""
+
+for LOCAL_PATH in "${!FILES[@]}"; do
+    URL="${FILES[$LOCAL_PATH]}"
+
+    if [ -f "$LOCAL_PATH" ]; then
+        echo "  ✓ EXISTS   $LOCAL_PATH"
+        continue
+    fi
+
+    mkdir -p "$(dirname "$LOCAL_PATH")"
+
+    echo "  ↓ FETCH    $LOCAL_PATH"
+    if command -v curl &>/dev/null; then
+        curl -fsSL -o "$LOCAL_PATH" "$URL"
+    elif command -v wget &>/dev/null; then
+        wget -q -O "$LOCAL_PATH" "$URL"
+    else
+        echo "  ✗ ERROR    Neither curl nor wget found. Install one of them first."
+        exit 1
+    fi
+done
+
+echo ""
+echo "All checkpoints downloaded. You can now skip the 'git lfs pull' step."


### PR DESCRIPTION
## Summary

When Git LFS bandwidth is exceeded (free tier: 1 GB/month), users cannot clone the SongFormer checkpoints. This PR adds a fallback download script that fetches the same binaries from GitHub Releases instead.

## Changes

- **scripts/download_model_checkpoints.sh**: Downloads SongFormer, MuQ, MusicFM, and ChordMini checkpoints from a GitHub Release archive. Supports curl/wget, skips existing files, creates target directories automatically.
- **.gitignore**: Whitelists the new script.

## Testing

\\\ash
# Simulate a fresh clone without LFS
GIT_LFS_SKIP_SMUDGE=1 git lfs pull
./scripts/download_model_checkpoints.sh
# All checkpoints should be in place
ls -la SongFormer/src/SongFormer/ckpts/
\\\

## Notes

The Release archive needs to be created by the maintainer at \https://github.com/ptnghia-j/ChordMiniApp/releases/tag/model-checkpoints-v1\ containing the three LFS-tracked files. See the script header for the exact file list.

Closes #167