### PR TITLE
Split spleeter into optional requirements-spleeter.txt to resolve dependency conflicts

### DIFF
--- a/python_backend/requirements-spleeter.txt
+++ b/python_backend/requirements-spleeter.txt
@@ -1,0 +1,10 @@
+# ============================================================================
+# Spleeter requirements — separate because spleeter pins librosa<0.9.0 and
+# httpx<0.20.0, which conflicts with the main requirements.txt.
+#
+# Install only if you need Beat-Transformer source separation:
+#   pip install -r requirements-spleeter.txt
+# ============================================================================
+spleeter==2.3.2
+norbert==0.2.1
+ffmpeg-python==0.2.0

--- a/python_backend/requirements.txt
+++ b/python_backend/requirements.txt
@@ -47,11 +47,12 @@ torch==2.6.0
 torchaudio
 
 # ============================================================================
-# Spleeter - Real 5-stems Audio Separation (GPU Accelerated)
+# Spleeter — Real 5-stems Audio Separation (GPU Accelerated)
+# MOVED to requirements-spleeter.txt because spleeter pins librosa<0.9.0
+# and httpx<0.20.0 which conflicts with the rest of the stack.
+# Install only if you need Beat-Transformer source separation:
+#   pip install -r requirements-spleeter.txt
 # ============================================================================
-spleeter==2.3.2
-norbert==0.2.1
-ffmpeg-python==0.2.0
 
 # ============================================================================
 # Beat Detection and Music Analysis,
@@ -91,7 +92,7 @@ pumpp==0.6.0
 # ============================================================================
 requests==2.31.0
 httpx==0.28.1
-h2==4.1.0  # Required for Spleeter model downloads via HTTP/2
+h2==4.1.0
 Pillow==10.0.0
 lyricsgenius==3.6.2
 PyYAML==6.0.2


### PR DESCRIPTION
## Summary

spleeter==2.3.2 pins librosa<0.9.0 and httpx<0.20.0, which directly conflicts with the main requirements (\librosa==0.10.1\, \httpx==0.28.1\). This makes \pip install -r requirements.txt\ fail with \ResolutionImpossible\.

## Changes

- **python_backend/requirements-spleeter.txt** (new): contains spleeter + norbert + ffmpeg-python — install only when Beat-Transformer source separation is needed
- **python_backend/requirements.txt**: removed spleeter/norbert/ffmpeg-python lines; updated section header to point to the new file

## Usage

`ash
# Core stack (no conflicts)
pip install -r python_backend/requirements.txt

# Optional: add spleeter for Beat-Transformer
pip install -r python_backend/requirements-spleeter.txt
`

Closes #161